### PR TITLE
Don't need Crypt::Random if Bytes::Random::Secure is available

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,7 +28,6 @@ my %params = (
 				  'Crypt::CBC'     => 2.30,
 				  'Crypt::ECB'     => 1.45,
 				  'Crypt::Twofish' => 2.14,
-				  'Crypt::Random'  => 1.25,
 				  'Data::UUID'     => 1.217,
 				  'Shell'          => 0.5,
 				  'File::Temp'     => 0,
@@ -39,6 +38,14 @@ my %params = (
 				},
 		($ExtUtils::MakeMaker::VERSION >= 6.3002 ? ('LICENSE'  => 'perl', ) : ()),
 );
+
+# Already tried requiring Bytes::Random::Secure earlier, so now check the version
+# and if it's OK, add a dependency on it; otherwise, fall back to Crypt::Random
+if (eval { Bytes::Random::Secure->VERSION('0.09') }) {
+    $params{'PREREQ_PM'}{'Bytes::Random::Secure'} = 0.09;
+} else {
+    $params{'PREREQ_PM'}{'Crypt::Random'} = 1.25;
+};
 
 if ( $ExtUtils::MakeMaker::VERSION ge '6.46' ) {
     $params{META_MERGE} = {

--- a/lib/Crypt/PWSafe3.pm
+++ b/lib/Crypt/PWSafe3.pm
@@ -21,7 +21,6 @@ use Crypt::ECB;
 use Crypt::Twofish;
 use Digest::HMAC;
 use Digest::SHA;
-use Crypt::Random qw( makerandom );
 use Data::UUID;
 use File::Copy qw(copy move);
 use File::Temp;


### PR DESCRIPTION
`Crypt::PWSafe3` already prefers `Bytes::Random::Secure` over `Crypt::Random` but still has a hard dependency on it, via an unconditional `use Crypt::Random`. This is no longer necessary since `Crypt::Random` will be `require`-d if a suitably recent version of `Bytes::Random::Secure` cannot be found.

The `Makefile.PL` is also updated to reflect this approach.